### PR TITLE
New feed URL

### DIFF
--- a/worker/bloggers.xml
+++ b/worker/bloggers.xml
@@ -66,7 +66,7 @@
 	<Blogger Name="Pedro Martínez" RssUrl="http://pedromj.dyndns.org/blog/BlogXBrowsing.asmx/GetRss?" Head="Pedro.png"/>
 	<!--<Blogger Name="Brandon Hale" RssUrl="http://blog.brandonhale.us/xml/rss20/feed.xml" IrcNick="bhale"/>-->
 	<!--Blogger Name="Raja R Harinath" RssUrl="http://feeds.feedburner.com/hurrynot" Head="Harinath.jpg"/-->
-	<Blogger Name="Mirco Bauer" RssUrl="http://www.meebey.net/jaws/data/xml/blog.Mono.rss" IrcNick="meebey" Head="meebey.png"/>
+	<Blogger Name="Mirco Bauer" RssUrl="http://www.meebey.net/tags/planet-mono/index.rss" IrcNick="meebey" Head="meebey.png"/>
 	<Blogger Name="Michael Hutchinson" RssUrl="http://mjhutchinson.com/mono-feed" IrcNick="mhutch" Head="mhutch.png"/>
 	<Blogger Name="Jeff Tickle" RssUrl="http://blog.jefftickle.com/category/pub/rss2" IrcNick="jtickle" Head="jtickle.png" />
 	<Blogger Name="Marek Sieradzki" RssUrl="http://msieradzki.wordpress.com/feed/" IrcNick="msieradzki" />


### PR DESCRIPTION
I have replaced my Jaws blog with ikiwiki and the feed URL needs to be updated on monologue to fetch the new feed
