### PR TITLE
add inorton.wordpress.com to blogs

### DIFF
--- a/worker/bloggers.xml
+++ b/worker/bloggers.xml
@@ -225,4 +225,5 @@
 	<Blogger Name="Piotr Dowgiallo" RssUrl="http://pdowgiallo.pl/gsoc/feed/" IrcNick="sparek" />
 	<Blogger Name="Petar Dodev" RssUrl="http://petardodev.blogspot.com/feeds/posts/default/-/GSoC2012" IrcNick="dodev" />
 	<Blogger Name="Simon Lindgren" RssUrl="http://feeds.feedburner.com/simonl" IrcNick="simonl" />
+	<Blogger Name="Ian Norton" RssUrl="http://inorton.wordpress.com/category/mono/feed/" IrcNick="inb"/>
 </BloggerCollection>


### PR DESCRIPTION
I've added my blog feed about parallel mono packages for 32bit and 64bit debian/ubuntu. Please can you pull. I'd like to see how many more people find these packages useful.

Thanks

Ian