### PR TITLE
Updated my blog's RSS feed URL

### DIFF
--- a/worker/bloggers.xml
+++ b/worker/bloggers.xml
@@ -153,7 +153,7 @@
 	<Blogger Name="Debackerl" RssUrl="http://debackerl.wordpress.com/tag/soc-2007/feed/" />
 	<Blogger Name="Nidhi Rawal" RssUrl="http://nidhi24.wordpress.com/?feed=rss" />
 	<Blogger Name="Jared Hendry" RssUrl="http://buchan.esoteriq.org/weblog/category/mono/feed" />
-	<Blogger Name="Chris Howie" RssUrl="http://www.chrishowie.com/feed/" IrcNick="SerajewelKS" Head="chrishowie.png"/>
+	<Blogger Name="Chris Howie" RssUrl="http://blog.chrishowie.com/feed/" IrcNick="SerajewelKS" Head="chrishowie.png"/>
 	<Blogger Name="Chris Gameweld" RssUrl="http://gameweld-soc.blogspot.com/feeds/posts/default?alt=rss" />
 	<Blogger Name="Valentin Sawadski" RssUrl="http://achblah.blogspot.com/feeds/posts/default?alt=rss" />
 	<Blogger Name="Seo Sanghyeon" RssUrl="http://fepy.blogspot.com/feeds/posts/default?alt=rss" IrcNick="sanxiyn"/>


### PR DESCRIPTION
The old URL redirects to the new one so it's working right now, but I'd rather not have Monologue depending on the old URL.
