### PR TITLE
Fix knocte's hackergotchi

### DIFF
--- a/worker/bloggers.xml
+++ b/worker/bloggers.xml
@@ -181,7 +181,7 @@
   <Blogger Name    = "Andrés G. Aragoneses"
            RssUrl  = "http://knocte.blogspot.com/feeds/posts/default/-/Mono?alt=rss"
            IrcNick = "knocte"
-           Head    = "http://www.mono-project.com/files/5/54/Knocte.png"
+           Head    = "http://planet.gnome.org/heads/knocte.png"
            />
 	<Blogger Name="Noam Lampert" RssUrl="http://noamlampert.blogspot.com/feeds/posts/default?alt=rss"/>
 	<!-- 404


### PR DESCRIPTION
Mono's wikimedia-based wiki is no more, so this head was not accessible anymore. Replace it with the hackergotchi file I have hosted in planet.gnome.org.
